### PR TITLE
Update to CornerCamper Colors

### DIFF
--- a/CornerCamper
+++ b/CornerCamper
@@ -97,9 +97,9 @@ public class CornerCamper extends TeamRobot {
      */
     private void setDefenderColor() {
         setBodyColor(new Color(0, 0, 0));
-        setGunColor(new Color(255, 0, 0));
+        setGunColor(new Color(0, 0, 255));
         setRadarColor(new Color(0, 0, 0));
-        setBulletColor(new Color(255, 0, 0));
+        setBulletColor(new Color(0, 0, 255));
         setScanColor(new Color(0, 0, 0));
     }
 


### PR DESCRIPTION
This patch fixes the colors of the CornerCamper to match the black/blue scheme instead of the previously used black/red scheme which belongs to the CornerDefenders.